### PR TITLE
content body for brew tap and install compliance-masonry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # homebrew-compliance-masonry
-Homebrew recipies for compliance-masonry
+
+Homebrew recipes for `compliance-masonry`
+
+```sh
+brew tap opencontrol/compliance-masonry
+brew install compliance-masonry
+```


### PR DESCRIPTION
In order to provide a smidgeon more ease-of-use for mac brew users, this PR fills out a smidgeon more detail in the README body on the homebrew tap README